### PR TITLE
Feature/motivation quotes

### DIFF
--- a/app/components/header/Header.styled.tsx
+++ b/app/components/header/Header.styled.tsx
@@ -89,7 +89,7 @@ export const IconButton = styled.button<{ $bgImage?: boolean }>`
   transition: var(--transition);
   @media (hover: hover) and (pointer: fine) {
     &:hover {
-      transform: var(--hover-transform);
+      :var(--hover-) ;
       box-shadow: var(--shadow-medium);
     }
   }

--- a/app/components/home/Initilizer.tsx
+++ b/app/components/home/Initilizer.tsx
@@ -11,18 +11,30 @@ import {
   initilizecustomBackgrounds,
   setCurrentBackground,
 } from "../../redux/slices/appearanceSlice";
+import {
+  initilizeIsQuotesShown,
+  setCurrentQuote,
+  setCustomQuote,
+} from "../../redux/slices/quotesSlice";
 
 export const Initilizer = () => {
   const dispatch = useDispatch();
 
   const streak = useSelector((state: RootState) => state.app.streak);
   const currentTab = useSelector((state: RootState) => state.app.currentTab);
+
   const { tasks, currentTaskId } = useSelector(tasksSelectors);
   const currentBackground = useSelector(
     (state: RootState) => state.appearance.currentBackground
   );
   const customBackgrounds = useSelector(
     (state: RootState) => state.appearance.customBackgrounds
+  );
+  const isQuotesShown = useSelector(
+    (state: RootState) => state.quotes.isQuotesShown
+  );
+  const customQuote = useSelector(
+    (state: RootState) => state.quotes.customQuote
   );
   useEffect(() => {
     const streakStore = localStorage.getItem("streak");
@@ -32,6 +44,9 @@ export const Initilizer = () => {
     const tasksStore = localStorage.getItem("tasks");
     const currentBackgroundStore = localStorage.getItem("currentBackground");
     const customBackgroundsStore = localStorage.getItem("customBackgrounds");
+    const isQuotesShownStore = localStorage.getItem("isQuotesShown");
+    const quoteIndexStore = localStorage.getItem("quoteIndex");
+    const customQuoteStore = localStorage.getItem("customQuote");
     if (streakStore !== null) {
       dispatch(initStreak({ value: JSON.parse(streakStore) }));
     }
@@ -57,6 +72,15 @@ export const Initilizer = () => {
         initilizecustomBackgrounds({ data: JSON.parse(customBackgroundsStore) })
       );
     }
+    if (isQuotesShownStore !== null) {
+      dispatch(initilizeIsQuotesShown({ val: JSON.parse(isQuotesShownStore) }));
+    }
+    if (quoteIndexStore !== null) {
+      dispatch(setCurrentQuote({ index: JSON.parse(quoteIndexStore) }));
+    }
+    if (customQuoteStore !== null) {
+      dispatch(setCustomQuote({ value: JSON.parse(customQuoteStore) }));
+    }
   }, [dispatch]);
 
   useEffect(() => {
@@ -72,6 +96,8 @@ export const Initilizer = () => {
       "customBackgrounds",
       JSON.stringify(customBackgrounds)
     );
+    localStorage.setItem("isQuotesShown", JSON.stringify(isQuotesShown));
+    localStorage.setItem("customQuote", JSON.stringify(customQuote));
   }, [
     currentTab,
     streak,
@@ -79,6 +105,8 @@ export const Initilizer = () => {
     currentTaskId,
     currentBackground,
     customBackgrounds,
+    isQuotesShown,
+    customQuote,
   ]);
 
   return null;

--- a/app/components/home/ModeTime.tsx
+++ b/app/components/home/ModeTime.tsx
@@ -6,6 +6,7 @@ import StopWatch from "./Stopwatch";
 import React from "react";
 import Focus from "./Focus";
 import Clock from "./Clock";
+import { Quotes } from "./quote/Quote";
 
 export const ModeTime = () => {
   const currentTab = useSelector((state: RootState) => state.app.currentTab);
@@ -19,6 +20,7 @@ export const ModeTime = () => {
   };
   return (
     <React.Fragment>
+      <Quotes />
       {currentTab === "focusTime" ? (
         <Focus formatTime={formatTime} />
       ) : currentTab === "stopwatch" ? (

--- a/app/components/home/quote/Quote.styled.tsx
+++ b/app/components/home/quote/Quote.styled.tsx
@@ -31,6 +31,12 @@ export const QuoteDisplayText = styled.p<{ $bgImage?: boolean }>`
       transform: var(--hover-transform);
     }
   }
+`;
+export const QuoteDisplayInput = styled(QuoteDisplayText)`
+  border: none;
+  background-color: transparent;
+  width: 100%;
+
   &:focus,
   &:active {
     outline: none;

--- a/app/components/home/quote/Quote.styled.tsx
+++ b/app/components/home/quote/Quote.styled.tsx
@@ -4,7 +4,7 @@ import { media } from "../../../styles/breakpoints";
 export const QuoteSection = styled.section`
   text-align: center;
   width: 100%;
-  max-width: 40rem;
+  max-width: 38rem;
   margin: 0 auto;
   display: flex;
   justify-content: center;
@@ -25,14 +25,17 @@ export const QuoteDisplayText = styled.p<{ $bgImage?: boolean }>`
   line-height: 1.3;
   cursor: pointer;
   transition: var(--transition);
-
-  &:hover {
-    color: ${({ theme }) => theme.highlight};
-    transform: var(--hover-transform);
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      color: ${({ theme }) => theme.highlight};
+      transform: var(--hover-transform);
+    }
   }
   &:focus,
   &:active {
+    outline: none;
     color: ${({ theme }) => theme.highlight};
-    border: 1px solid ${({ theme }) => theme.highlight};
+    border-bottom: 2px solid ${({ theme }) => theme.highlight};
+    cursor: auto;
   }
 `;

--- a/app/components/home/quote/Quote.styled.tsx
+++ b/app/components/home/quote/Quote.styled.tsx
@@ -1,0 +1,38 @@
+import styled from "styled-components";
+import { media } from "../../../styles/breakpoints";
+
+export const QuoteSection = styled.section`
+  text-align: center;
+  width: 100%;
+  max-width: 40rem;
+  margin: 0 auto;
+  display: flex;
+  justify-content: center;
+
+  div {
+    position: relative;
+  }
+  @media ${media.md} {
+    width: 80%;
+  }
+`;
+
+export const QuoteDisplayText = styled.p<{ $bgImage?: boolean }>`
+  font-size: 1.5rem;
+  font-weight: 500;
+  padding: 10px 6px;
+  color: ${({ $bgImage, theme }) => ($bgImage ? theme.background : theme.text)};
+  line-height: 1.3;
+  cursor: pointer;
+  transition: var(--transition);
+
+  &:hover {
+    color: ${({ theme }) => theme.highlight};
+    transform: var(--hover-transform);
+  }
+  &:focus,
+  &:active {
+    color: ${({ theme }) => theme.highlight};
+    border: 1px solid ${({ theme }) => theme.highlight};
+  }
+`;

--- a/app/components/home/quote/Quote.tsx
+++ b/app/components/home/quote/Quote.tsx
@@ -1,0 +1,55 @@
+"use client";
+import { useDispatch, useSelector } from "react-redux";
+import { RootState } from "../../../redux/store";
+import {
+  setCustomQuote,
+  setIsEditingQuote,
+  setTempCustomQuote,
+} from "../../../redux/slices/quotesSlice";
+
+import { QuoteDisplay, QuoteDisplayText, QuoteSection } from "./Quote.styled";
+import { useBackgroundStatus } from "../../../hooks/useBackgroundStatus";
+
+export const Quotes = () => {
+  const dispatch = useDispatch();
+  const isBackgroundActive = useBackgroundStatus();
+  const isQuotesShown = useSelector(
+    (state: RootState) => state.quotes.isQuotesShown
+  );
+  // const isEditingQuote = useSelector(
+  //   (state: RootState) => state.quotes.isEditingQuote
+  // );
+  const customQuote = useSelector(
+    (state: RootState) => state.quotes.customQuote
+  );
+  const currentQuote = useSelector(
+    (state: RootState) => state.quotes.currentQuote
+  );
+  const tempCustomQuote = useSelector(
+    (state: RootState) => state.quotes.tempCustomQuote
+  );
+  const handleIsEditingQuote = () => {
+    dispatch(setIsEditingQuote());
+  };
+  const handleTempQuote = (val: string) => {
+    dispatch(setTempCustomQuote({ value: val }));
+  };
+  const handleCustomQuote = () => {
+    dispatch(setCustomQuote({ value: tempCustomQuote }));
+  };
+  return (
+    <QuoteSection>
+      {isQuotesShown && (
+        <QuoteDisplayText
+          $bgImage={isBackgroundActive}
+          contentEditable={true}
+          suppressContentEditableWarning={true}
+          onInput={(e) => handleTempQuote((e.target as HTMLElement).innerText)}
+          onBlur={handleCustomQuote}
+          aria-label="Edit quote">
+          {customQuote || currentQuote}
+        </QuoteDisplayText>
+      )}
+    </QuoteSection>
+  );
+};

--- a/app/components/home/quote/Quote.tsx
+++ b/app/components/home/quote/Quote.tsx
@@ -7,8 +7,13 @@ import {
   setTempCustomQuote,
 } from "../../../redux/slices/quotesSlice";
 
-import { QuoteDisplay, QuoteDisplayText, QuoteSection } from "./Quote.styled";
+import {
+  QuoteDisplayInput,
+  QuoteDisplayText,
+  QuoteSection,
+} from "./Quote.styled";
 import { useBackgroundStatus } from "../../../hooks/useBackgroundStatus";
+import React from "react";
 
 export const Quotes = () => {
   const dispatch = useDispatch();
@@ -16,9 +21,9 @@ export const Quotes = () => {
   const isQuotesShown = useSelector(
     (state: RootState) => state.quotes.isQuotesShown
   );
-  // const isEditingQuote = useSelector(
-  //   (state: RootState) => state.quotes.isEditingQuote
-  // );
+  const isEditingQuote = useSelector(
+    (state: RootState) => state.quotes.isEditingQuote
+  );
   const customQuote = useSelector(
     (state: RootState) => state.quotes.customQuote
   );
@@ -30,26 +35,37 @@ export const Quotes = () => {
   );
   const handleIsEditingQuote = () => {
     dispatch(setIsEditingQuote());
+    dispatch(setTempCustomQuote({ value: customQuote || currentQuote }));
   };
   const handleTempQuote = (val: string) => {
     dispatch(setTempCustomQuote({ value: val }));
   };
   const handleCustomQuote = () => {
+    dispatch(setIsEditingQuote());
     dispatch(setCustomQuote({ value: tempCustomQuote }));
   };
   return (
-    <QuoteSection>
+    <React.Fragment>
       {isQuotesShown && (
-        <QuoteDisplayText
-          $bgImage={isBackgroundActive}
-          contentEditable={true}
-          suppressContentEditableWarning={true}
-          onInput={(e) => handleTempQuote((e.target as HTMLElement).innerText)}
-          onBlur={handleCustomQuote}
-          aria-label="Edit quote">
-          {customQuote || currentQuote}
-        </QuoteDisplayText>
+        <QuoteSection>
+          {isEditingQuote ? (
+            <QuoteDisplayInput
+              as={"textarea"}
+              autoFocus
+              value={tempCustomQuote}
+              onChange={(e) => handleTempQuote(e.target.value)}
+              onBlur={handleCustomQuote}
+              rows={1}
+            />
+          ) : (
+            <QuoteDisplayText
+              $bgImage={isBackgroundActive}
+              onClick={handleIsEditingQuote}>
+              {customQuote || currentQuote}
+            </QuoteDisplayText>
+          )}
+        </QuoteSection>
       )}
-    </QuoteSection>
+    </React.Fragment>
   );
 };

--- a/app/components/settings-modal/SettingsModal.tsx
+++ b/app/components/settings-modal/SettingsModal.tsx
@@ -18,6 +18,7 @@ import {
 } from "./Settings.styled";
 import { AppearanceTab } from "./appearance-tab/AppearanceTab";
 import { useBackgroundStatus } from "../../hooks/useBackgroundStatus";
+import { FeaturesTab } from "./features-tab/FeaturesTab";
 
 const SettingsModal = () => {
   const dispatch = useDispatch();
@@ -87,6 +88,7 @@ const SettingsModal = () => {
           </SettingsTabs>
           {settingsTab === "timer" && <TimerTab />}
           {settingsTab === "appearance" && <AppearanceTab />}
+          {settingsTab === "features" && <FeaturesTab />}
         </ModalBody>
       </Modal>
     </Overlay>

--- a/app/components/settings-modal/features-tab/Features.styled.tsx
+++ b/app/components/settings-modal/features-tab/Features.styled.tsx
@@ -1,0 +1,60 @@
+import styled from "styled-components";
+import { media } from "../../../styles/breakpoints";
+
+export const SettingsContent = styled.form`
+  flex: 1;
+  max-height: 95vh;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  overflow-y: scroll;
+  padding-bottom: 2rem;
+  @media ${media.md} {
+    max-height: 95vh;
+  }
+`;
+
+export const SettingGroup = styled.fieldset`
+  padding-top: 10px;
+  border: none;
+`;
+
+export const SectionHeading = styled.legend`
+  font-family: var(--font-outfit);
+  font-size: 1.1rem;
+  font-weight: 800;
+`;
+
+export const QuoteGroup = styled.div`
+  display: flex;
+  flex-direction: row;
+  gap: 10px;
+  align-item: center;
+
+  button {
+    background: transparent;
+    border: none;
+    cursor: pointer;
+  }
+`;
+export const CurrentQuote = styled.i`
+  font-weight: 400;
+`;
+export const CurrentQuoteWarning = styled(CurrentQuote)`
+  color: ${({ theme }) => theme.highlight};
+`;
+
+export const QuoteTextArea = styled.textarea`
+  width: 100%;
+  max-width: 18rem;
+  padding: 12px;
+  border: 1px solid ${({ theme }) => theme.text};
+  border-radius: 8px;
+  background-color: ${({ theme }) => theme.backgroundSecondary}
+  font-size: 14px;
+  color: var(--color-text);
+
+   @media ${media.md} {
+    max-width: 30rem;
+  }
+`;

--- a/app/components/settings-modal/features-tab/Features.styled.tsx
+++ b/app/components/settings-modal/features-tab/Features.styled.tsx
@@ -9,6 +9,7 @@ export const SettingsContent = styled.form`
   gap: 2rem;
   overflow-y: scroll;
   padding-bottom: 2rem;
+
   @media ${media.md} {
     max-height: 95vh;
   }
@@ -47,14 +48,21 @@ export const CurrentQuoteWarning = styled(CurrentQuote)`
 export const QuoteTextArea = styled.textarea`
   width: 100%;
   max-width: 18rem;
+  max-height: 13rem;
   padding: 12px;
   border: 1px solid ${({ theme }) => theme.text};
   border-radius: 8px;
   background-color: ${({ theme }) => theme.backgroundSecondary}
-  font-size: 14px;
-  color: var(--color-text);
+  font-size: 0.9rem;
+  color:  ${({ theme }) => theme.text}
 
    @media ${media.md} {
     max-width: 30rem;
+  }
+
+  &:focus, &:active {
+   outline: none;
+    border: 2px solid ${({ theme }) => theme.highlight};
+    cursor: auto;
   }
 `;

--- a/app/components/settings-modal/features-tab/Features.styled.tsx
+++ b/app/components/settings-modal/features-tab/Features.styled.tsx
@@ -28,16 +28,34 @@ export const SectionHeading = styled.legend`
 
 export const QuoteGroup = styled.div`
   display: flex;
-  flex-direction: row;
-  gap: 10px;
-  align-item: center;
+  flex-direction: column;
+  gap: 20px;
+`;
 
-  button {
-    background: transparent;
-    border: none;
-    cursor: pointer;
+export const RandomQuoteButton = styled.button`
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  background-color: ${({ theme }) => theme.highlight};
+  color: white;
+  border: none;
+  padding: 8px;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: var(--transition);
+  font-size: 1rem;
+  font-family: var(--font-outfit);
+  width: max-content;
+
+  @media (hover: hover) and (pointer: fine) {
+    &:hover {
+      transform: var(--hover-transform);
+    }
   }
 `;
+
 export const CurrentQuote = styled.i`
   font-weight: 400;
 `;
@@ -50,7 +68,7 @@ export const QuoteTextArea = styled.textarea`
   max-width: 18rem;
   max-height: 13rem;
   padding: 12px;
-  border: 1px solid ${({ theme }) => theme.text};
+  border: 2px solid ${({ theme }) => theme.text};
   border-radius: 8px;
   background-color: ${({ theme }) => theme.backgroundSecondary}
   font-size: 0.9rem;

--- a/app/components/settings-modal/features-tab/FeaturesTab.tsx
+++ b/app/components/settings-modal/features-tab/FeaturesTab.tsx
@@ -44,6 +44,8 @@ export const FeaturesTab = () => {
 
   const pickRandomQuote = useCallback(() => {
     const randomIndex = Math.floor(Math.random() * quotes.length);
+    localStorage.setItem("quoteIndex", JSON.stringify(randomIndex));
+
     dispatch(setCurrentQuote({ index: randomIndex }));
   }, [quotes, dispatch]);
 

--- a/app/components/settings-modal/features-tab/FeaturesTab.tsx
+++ b/app/components/settings-modal/features-tab/FeaturesTab.tsx
@@ -18,7 +18,7 @@ import {
 import { RootState } from "../../../redux/store";
 import { useCallback, useEffect } from "react";
 import { CheckboxLabel } from "../timer-tab/Timer.styled";
-import { Dices, Trash } from "lucide-react";
+import { RefreshCw, Trash } from "lucide-react";
 
 export const FeaturesTab = () => {
   const dispatch = useDispatch();
@@ -31,6 +31,7 @@ export const FeaturesTab = () => {
   const currentQuote = useSelector(
     (state: RootState) => state.quotes.currentQuote
   );
+
   const quotes = useSelector((state: RootState) => state.quotes.quotes);
 
   const handleShowQuotes = () => {
@@ -75,7 +76,7 @@ export const FeaturesTab = () => {
               onClick={pickRandomQuote}
               type="button"
               aria-label="Generate random quote">
-              <Dices />
+              <RefreshCw />
             </button>
           </QuoteGroup>
         </SettingGroup>

--- a/app/components/settings-modal/features-tab/FeaturesTab.tsx
+++ b/app/components/settings-modal/features-tab/FeaturesTab.tsx
@@ -5,6 +5,7 @@ import {
   CurrentQuoteWarning,
   QuoteGroup,
   QuoteTextArea,
+  RandomQuoteButton,
   SectionHeading,
   SettingGroup,
   SettingsContent,
@@ -18,7 +19,7 @@ import {
 import { RootState } from "../../../redux/store";
 import { useCallback, useEffect } from "react";
 import { CheckboxLabel } from "../timer-tab/Timer.styled";
-import { RefreshCw, Trash } from "lucide-react";
+import { Shuffle } from "lucide-react";
 
 export const FeaturesTab = () => {
   const dispatch = useDispatch();
@@ -72,15 +73,17 @@ export const FeaturesTab = () => {
           <SectionHeading>Here is a random quote:</SectionHeading>
           <QuoteGroup>
             <CurrentQuote>&quot;{currentQuote}&quot;</CurrentQuote>
-            <button
+            <RandomQuoteButton
               onClick={pickRandomQuote}
               type="button"
               aria-label="Generate random quote">
-              <RefreshCw />
-            </button>
+              Show me another quote
+              <Shuffle />
+            </RandomQuoteButton>
           </QuoteGroup>
         </SettingGroup>
       )}
+
       {customQuote && (
         <CurrentQuoteWarning>
           To enable random quotes, remove your custom quote
@@ -100,12 +103,6 @@ export const FeaturesTab = () => {
               <SectionHeading>Here is your quote:</SectionHeading>
               <QuoteGroup>
                 <CurrentQuote>&quot;{customQuote}&quot;</CurrentQuote>
-                <button
-                  onClick={() => handleCustomQuote("")}
-                  type="button"
-                  aria-label="Generate random quote">
-                  <Trash />
-                </button>
               </QuoteGroup>
             </SettingGroup>
           )}

--- a/app/components/settings-modal/features-tab/FeaturesTab.tsx
+++ b/app/components/settings-modal/features-tab/FeaturesTab.tsx
@@ -1,0 +1,115 @@
+"use client";
+import { useDispatch, useSelector } from "react-redux";
+import {
+  CurrentQuote,
+  CurrentQuoteWarning,
+  QuoteGroup,
+  QuoteTextArea,
+  SectionHeading,
+  SettingGroup,
+  SettingsContent,
+} from "./Features.styled";
+
+import {
+  setCurrentQuote,
+  setCustomQuote,
+  showQuotes,
+} from "../../../redux/slices/quotesSlice";
+import { RootState } from "../../../redux/store";
+import { useCallback, useEffect } from "react";
+import { CheckboxLabel } from "../timer-tab/Timer.styled";
+import { Dices, Trash } from "lucide-react";
+
+export const FeaturesTab = () => {
+  const dispatch = useDispatch();
+  const isQuotesShown = useSelector(
+    (state: RootState) => state.quotes.isQuotesShown
+  );
+  const customQuote = useSelector(
+    (state: RootState) => state.quotes.customQuote
+  );
+  const currentQuote = useSelector(
+    (state: RootState) => state.quotes.currentQuote
+  );
+  const quotes = useSelector((state: RootState) => state.quotes.quotes);
+
+  const handleShowQuotes = () => {
+    dispatch(showQuotes());
+  };
+  const handleCustomQuote = (val: string) => {
+    dispatch(setCustomQuote({ value: val }));
+  };
+
+  const pickRandomQuote = useCallback(() => {
+    const randomIndex = Math.floor(Math.random() * quotes.length);
+    dispatch(setCurrentQuote({ index: randomIndex }));
+  }, [quotes, dispatch]);
+
+  useEffect(() => {
+    pickRandomQuote();
+    const interval = setInterval(() => {
+      pickRandomQuote();
+    }, 25 * 60 * 1000);
+    return () => clearInterval(interval);
+  }, [dispatch, quotes, pickRandomQuote]);
+  return (
+    <SettingsContent>
+      <SettingGroup>
+        <SectionHeading>Motivational Quotes</SectionHeading>
+        <CheckboxLabel htmlFor="showQuote">
+          <input
+            id="showQuote"
+            type="checkbox"
+            checked={isQuotesShown}
+            onChange={handleShowQuotes}
+          />
+          Show motivational quotes
+        </CheckboxLabel>
+      </SettingGroup>
+      {isQuotesShown && currentQuote && (
+        <SettingGroup>
+          <SectionHeading>Here is a random quote:</SectionHeading>
+          <QuoteGroup>
+            <CurrentQuote>&quot;{currentQuote}&quot;</CurrentQuote>
+            <button
+              onClick={pickRandomQuote}
+              type="button"
+              aria-label="Generate random quote">
+              <Dices />
+            </button>
+          </QuoteGroup>
+        </SettingGroup>
+      )}
+      {customQuote && (
+        <CurrentQuoteWarning>
+          To enable random quotes, remove your custom quote
+        </CurrentQuoteWarning>
+      )}
+      {isQuotesShown && (
+        <SettingGroup>
+          <SectionHeading>Custom Quote (optional)</SectionHeading>
+          <QuoteTextArea
+            value={customQuote || ""}
+            onChange={(e) => handleCustomQuote(e.target.value)}
+            placeholder="Enter your custom motivational quote..."
+            rows={3}
+          />
+          {isQuotesShown && customQuote && (
+            <SettingGroup>
+              <SectionHeading>Here is your quote:</SectionHeading>
+              <QuoteGroup>
+                <CurrentQuote>&quot;{customQuote}&quot;</CurrentQuote>
+                <button
+                  onClick={() => handleCustomQuote("")}
+                  type="button"
+                  aria-label="Generate random quote">
+                  <Trash />
+                </button>
+              </QuoteGroup>
+            </SettingGroup>
+          )}
+        </SettingGroup>
+      )}
+    </SettingsContent>
+  );
+};

--- a/app/lib/constants.ts
+++ b/app/lib/constants.ts
@@ -1,2 +1,14 @@
 export const MAX_FILE_SIZE_MB = 2;
 export const MAX_FILE_SIZE_BYTES = MAX_FILE_SIZE_MB * 1024 * 1024;
+export const MOTIVATIONAL_QUOTES = [
+  "Focus is not about doing more, it's about doing what matters",
+  "Small steps lead to big changes",
+  "Your future self will thank you for the work you do today",
+  "Progress, not perfection",
+  "Every moment of focus is a gift to yourself",
+  "Breathe, focus, achieve",
+  "You've got this! One pomodoro at a time",
+  "Deep work creates deep satisfaction",
+  "Clarity comes from focused attention",
+  "The best time to focus is now",
+];

--- a/app/redux/slices/quotesSlice.ts
+++ b/app/redux/slices/quotesSlice.ts
@@ -1,0 +1,47 @@
+import { createSlice } from "@reduxjs/toolkit";
+import { MOTIVATIONAL_QUOTES } from "../../lib/constants";
+
+const quotesSlice = createSlice({
+  name: "quotes",
+  initialState: {
+    quotes: [...MOTIVATIONAL_QUOTES],
+    isQuotesShown: false,
+    currentQuote: "",
+    customQuote: "",
+    tempCustomQuote: "",
+    isEditingQuote: false,
+  },
+  reducers: {
+    showQuotes(state) {
+      state.isQuotesShown = !state.isQuotesShown;
+      if (!state.isQuotesShown) {
+        state.customQuote = "";
+      }
+    },
+    setCustomQuote(state, action) {
+      const val = action.payload.value;
+      state.customQuote = val;
+      state.isEditingQuote = false;
+    },
+    setTempCustomQuote(state, action) {
+      const val = action.payload.value;
+      state.tempCustomQuote = val;
+    },
+    setIsEditingQuote(state) {
+      state.isEditingQuote = !state.isEditingQuote;
+    },
+    setCurrentQuote(state, action) {
+      const index = action.payload.index;
+      state.currentQuote = state.quotes[index];
+    },
+  },
+});
+
+export default quotesSlice.reducer;
+export const {
+  showQuotes,
+  setCustomQuote,
+  setIsEditingQuote,
+  setTempCustomQuote,
+  setCurrentQuote,
+} = quotesSlice.actions;

--- a/app/redux/slices/quotesSlice.ts
+++ b/app/redux/slices/quotesSlice.ts
@@ -18,6 +18,10 @@ const quotesSlice = createSlice({
         state.customQuote = "";
       }
     },
+    initilizeIsQuotesShown(state, action) {
+      const isShown = action.payload.val;
+      state.isQuotesShown = isShown;
+    },
     setCustomQuote(state, action) {
       const val = action.payload.value;
       state.customQuote = val;
@@ -44,4 +48,5 @@ export const {
   setTempCustomQuote,
   setCurrentQuote,
   setIsEditingQuote,
+  initilizeIsQuotesShown,
 } = quotesSlice.actions;

--- a/app/redux/slices/quotesSlice.ts
+++ b/app/redux/slices/quotesSlice.ts
@@ -21,18 +21,18 @@ const quotesSlice = createSlice({
     setCustomQuote(state, action) {
       const val = action.payload.value;
       state.customQuote = val;
-      state.isEditingQuote = false;
     },
     setTempCustomQuote(state, action) {
       const val = action.payload.value;
       state.tempCustomQuote = val;
     },
-    setIsEditingQuote(state) {
-      state.isEditingQuote = !state.isEditingQuote;
-    },
+
     setCurrentQuote(state, action) {
       const index = action.payload.index;
       state.currentQuote = state.quotes[index];
+    },
+    setIsEditingQuote(state) {
+      state.isEditingQuote = !state.isEditingQuote;
     },
   },
 });
@@ -41,7 +41,7 @@ export default quotesSlice.reducer;
 export const {
   showQuotes,
   setCustomQuote,
-  setIsEditingQuote,
   setTempCustomQuote,
   setCurrentQuote,
+  setIsEditingQuote,
 } = quotesSlice.actions;

--- a/app/redux/store.ts
+++ b/app/redux/store.ts
@@ -8,6 +8,7 @@ import stopwatchSlice from "./slices/stopwatchSlice";
 import tasksSlice from "./slices/tasksSlice";
 import appSLice from "./slices/appSlice";
 import appearanceSlice from "./slices/appearanceSlice";
+import quotesSlice from "./slices/quotesSlice";
 
 export const store = configureStore({
   reducer: {
@@ -19,6 +20,7 @@ export const store = configureStore({
     tasks: tasksSlice,
     app: appSLice,
     appearance: appearanceSlice,
+    quotes: quotesSlice,
   },
 });
 


### PR DESCRIPTION
Add predefined motivational quotes and let the user show them above the timers by toggling the option in settings.
Allow the user to add custom quotes and let them delete or edit existing ones.
Allow the user to edit the quote directly where it's displayed without having to go to the settings.
Save quote options in the localStorage to persist reloads.

Resolves #18 