### PR TITLE
replace custom background removal icon with trash icon and set highlight color as background to match the theme

### DIFF
--- a/app/components/settings-modal/appearance-tab/Appearance.styled.tsx
+++ b/app/components/settings-modal/appearance-tab/Appearance.styled.tsx
@@ -120,11 +120,12 @@ export const RemoveBackgroundButton = styled.button`
   z-index: 9999;
   top: -8px;
   right: -8px;
-  background-color: ${({ theme }) => theme.boxShadowTimer};
+  background-color: ${({ theme }) => theme.highlight};
   border-radius: 50%;
   border-width: 1px;
   border-style: solid;
   border-color: ${({ theme }) => theme.text};
+  color: ${({ theme }) => theme.background};
   width: 2rem;
   height: 2rem;
   cursor: pointer;
@@ -135,7 +136,7 @@ export const RemoveBackgroundButton = styled.button`
   transition: var(--transition);
 
   svg {
-    border-color: ${({ theme }) => theme.text};
+    border-color: ${({ theme }) => theme.background};
   }
   @media (hover: hover) and (pointer: fine) {
     &:hover {

--- a/app/components/settings-modal/appearance-tab/AppearanceTab.tsx
+++ b/app/components/settings-modal/appearance-tab/AppearanceTab.tsx
@@ -36,6 +36,7 @@ import Upload from "lucide-react/dist/esm/icons/upload";
 
 import { MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB } from "../../../lib/constants";
 import { appearanceSelectors } from "../../../redux/selectors/appearanceSelectors";
+import { Trash } from "lucide-react";
 export const AppearanceTab = () => {
   const dispatch = useDispatch();
 
@@ -134,8 +135,10 @@ export const AppearanceTab = () => {
                   onClick={() => handleImageChange(bg, "custom")}>
                   <Image src={bg} alt={`Background ${index + 1}`} width={300} height={300} />
                 </BackgroundOption>
-                <RemoveBackgroundButton aria-label="Remove this background">
-                  <X onClick={() => handleCustomBackground(bg)} />
+                <RemoveBackgroundButton
+                  aria-label="Delete this image permanently"
+                  title="Delete this image permanently">
+                  <Trash size={20} onClick={() => handleCustomBackground(bg)} />
                 </RemoveBackgroundButton>
               </SingleBackground>
             ))}


### PR DESCRIPTION

## Related Issue

Resolves #80 

- [x] I am assigned to this issue
- [x] The issue is marked "open for contribution"

---

## Type of Contribution

- [ ] Bug fix
- [x] Feature implementation

---

## What was implemented or fixed?

Replaced the custom background removal icon with the trash icon and set the highlight color to the background to match the theme

---

## Screenshots (optional)

Provide screenshots of the feature or fix.

---

## Checklist

- [x] I have read [Contribution Rules](https://gist.github.com/catherineisonline/4e35fb3f38e0711eac2d8d026cf6d040)
