### PR TITLE
fix oldPassword validation when there is no provided oldPassword

### DIFF
--- a/app/components/settings-modal/profile-tab/helpers/validate.ts
+++ b/app/components/settings-modal/profile-tab/helpers/validate.ts
@@ -22,7 +22,7 @@ export const validate = (form: Form, action: string) => {
         errors["fullname"] = "Full name is not valid";
       }
       if (newPassword) {
-        if (newPassword.trim().length > 0 && oldPassword.trim().length === 0) {
+        if (newPassword.trim().length > 0 && !oldPassword) {
           errors["oldPassword"] = "Include old password to change to a new one";
         } else if (!passwordReg.test(oldPassword)) {
           errors["oldPassword"] = "Password must be 8-16 characters and include at least 1 digit";


### PR DESCRIPTION
## Related Issue

Resolves #85 

- [x] I am assigned to this issue
- [x] The issue is marked "open for contribution"

---

## Type of Contribution

- [x] Bug fix
- [ ] Feature implementation

---

## What was implemented or fixed?

Fixed oldPassword validation when there is no provided oldPassword while trying to set a new password

---

## Screenshots (optional)

Provide screenshots of the feature or fix.

---

## Checklist

- [x] I have read [Contribution Rules](https://gist.github.com/catherineisonline/4e35fb3f38e0711eac2d8d026cf6d040)
