### PR TITLE
fixed digit width for all time containers to avoid unstable time width

### DIFF
--- a/app/components/home/Page.styled.tsx
+++ b/app/components/home/Page.styled.tsx
@@ -101,6 +101,7 @@ export const TimerDisplay = styled.time<{ $bgImage?: boolean }>`
   font-weight: 500;
   line-height: 7.5rem;
   color: ${({ $bgImage, theme }) => ($bgImage ? theme.background : theme.text)};
+  font-variant-numeric: tabular-nums;
   @media ${media.md} {
     font-size: clamp(6rem, 10vw, 10rem);
     line-height: 2.5rem;


### PR DESCRIPTION
## Related Issue

Resolves #73 

- [x] I am assigned to this issue
- [x] The issue is marked "open for contribution"

---

## Type of Contribution

- [x] Bug fix
- [ ] Feature implementation

---

## What was implemented or fixed?

Added font-variant-numeric: tabular-nums; to all timer containers

---

## Screenshots (optional)

Provide screenshots of the feature or fix.

---

## Checklist

- [x] I have read [Contribution Rules](https://gist.github.com/catherineisonline/4e35fb3f38e0711eac2d8d026cf6d040)
